### PR TITLE
Q6 lone supplier of a shared context

### DIFF
--- a/.github/workflows/exp-alpha.yml
+++ b/.github/workflows/exp-alpha.yml
@@ -6,6 +6,9 @@ name: exp-alpha
 
 on:
   pull_request:
+    paths-ignore:
+      - 'docs/**'
+      - '.github/**'
 
 jobs:
   check:

--- a/docs/notes.md
+++ b/docs/notes.md
@@ -1,1 +1,2 @@
 placeholder
+q6 probe


### PR DESCRIPTION
exp-alpha excluded by paths-ignore; only exp-beta publishes check